### PR TITLE
Add AI Planner Studio concept documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ packages/**/dist
 apps/**/.expo
 apps/mobile/android
 apps/mobile/ios
+
+.turbo

--- a/apps/docs/docs/ai-planner-studio.md
+++ b/apps/docs/docs/ai-planner-studio.md
@@ -1,0 +1,72 @@
+---
+sidebar_position: 2
+---
+
+# AI Planner Studio – Hyper-Personalized Planner Platform
+
+An AI-native planner factory that generates a unique, print-ready planner for every individual in about a minute. The system combines a five-factor "Planner DNA" quiz with adaptive layouts, contextual content, and flexible pricing to deliver a "Netflix for planners" experience.
+
+## Planner DNA System
+
+Users answer five visually guided questions that branch into thousands of combinations:
+
+1. **Life Mode** – Student, professional, parent, retiree, entrepreneur.
+2. **Brain Style** – Neurotypical, ADHD, anxiety, depression, ASD.
+3. **Aesthetic** – Minimal, colorful, dark, nature, geometric, kawaii.
+4. **Intensity** – Hourly, daily, weekly, or monthly focus.
+5. **Special Needs** – Medication tracking, mood, symptoms, projects, habits.
+
+## User Journey
+
+- **Hook (0-30s):** A headline contrasts $9 custom planners with $47 generic ones. Users pick an aesthetic and see an instant preview with a "See your full planner in 60 seconds" CTA.
+- **Personalization (30-90s):** Five smart questions use cards, icons, live previews, and auto-detected printer sizes instead of traditional forms.
+- **AI Magic (90-120s):** Templates, layouts, dopamine cues (for ADHD), tracking modules, and design layers are composed into a tailored PDF ready for preview.
+- **Reveal (120s+):** A flipping-book preview highlights key pages labeled with the user’s name and context, plus free sample downloads for email capture.
+
+## Pricing Psychology
+
+- **Instant Download:** $9 per planner.
+- **Season Pass:** $27 for unlimited planners over three months.
+- **Lifetime:** $97 discounted to $47 with a countdown timer.
+- **Commercial:** $197 license to resell generated planners.
+
+Anchoring keeps $9 feeling inexpensive, while timed lifetime discounts and seasonal passes drive upsells.
+
+## Technical Architecture
+
+- **Frontend Flow:** No initial login; flow moves from interactive preview → DNA quiz → AI animation → 3D preview → upsell → Stripe checkout → instant download.
+- **Backend Stack:** Next.js on Vercel, Supabase for profiles, OpenAI for content, Puppeteer for PDF generation, and Cloudflare R2 for storage. Estimated cost per planner: ~$0.30 with $9 revenue.
+
+## AI Features That Matter
+
+- **Smart Date System:** Start any day of the year, auto-holiday insertion, moon phases, and fiscal calendars.
+- **Adaptive Layouts:** Dynamically expand daily sections, adjust line spacing, and reflow for printer sizes (e.g., A5).
+- **Contextual Content:** Motivational quotes tuned to challenges, seasonal art, habit trackers aligned to goals, and QR codes to tutorials.
+
+## Growth and Virality
+
+- **Built-in Sharing:** Planner DNA graphics, "Planner Twins" matchmaking, a template marketplace (30% take rate), and TikTok-ready packing videos.
+- **Influencer Hijacking:** Gift commercial licenses to creators, let them sell exclusive designs, and funnel their audiences with affiliate discounts.
+
+## Retention Mechanics
+
+Focus on habit formation instead of subscriptions: weekly pre-filled "week ahead" emails, monthly art/quote refreshes, seasonal planner prompts, and streak badges.
+
+## Competitive Positioning
+
+- **Etsy Sellers:** Cannot personalize at scale, A/B test, or profitably match $9 pricing.
+- **Canva:** Too generic for planner buyers, lacks planner intelligence and dynamic dating, and overwhelms with complexity.
+
+## Launch Roadmap (0–$10K MRR in 30 Days)
+
+1. **Week 1:** Build anticipation on TikTok with daily progress updates and a waitlist featuring founding-member pricing.
+2. **Week 2:** Beta with 100 free planners, collect feedback, and fix the top three complaints.
+3. **Week 3:** Soft launch across planner communities (Reddit, Facebook, Pinterest).
+4. **Week 4:** Paid amplification via TikTok, Instagram Reels, and Google Ads.
+
+## Key Numbers and Success Factors
+
+- **Unit Economics:** CAC ~$3 via TikTok ads; LTV ~$47 (5 planners/year); immediate payback; ~97% margins.
+- **Scale Targets:** 1k users in month one ($9K), 5k by month three ($45K), 15k by month six ($135K), 50k by month twelve ($450K).
+- **Must Nail:** 60-second creation, flawless print margins, appealing aesthetics, and mobile-first usability.
+- **Must Avoid:** Feature creep, forcing subscriptions, login friction, and overwhelming customization.


### PR DESCRIPTION
## Summary
- add a Docusaurus page describing the AI Planner Studio personalization, pricing, and launch strategy
- ignore local Turborepo cache directory in version control

## Testing
- not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693718555d40832abf3b1eecbbf5d31f)